### PR TITLE
[fix]SecurityContextの初期値バグの修正

### DIFF
--- a/Security/SecurityContext.php
+++ b/Security/SecurityContext.php
@@ -9,7 +9,7 @@ class SecurityContext
 {
     protected static $instance;
     public $secure = false;
-    public $domain = 'secured';
+    public $domain = 'secure';
     public $redirectUrl;
     public $allowedRoles = [];
     public $previousUrlHolder;

--- a/Tests/Security/SecurityContextTest.php
+++ b/Tests/Security/SecurityContextTest.php
@@ -23,6 +23,11 @@ class SecurityContextTest extends \Mockery\Adapter\Phpunit\MockeryTestCase
         $this->context->isAuthenticated();
     }
 
+    public function testDefault()
+    {
+        $this->assertEquals('secure', $this->context->domain);
+    }
+
     public function testSetSecure()
     {
         $this->context->setSecure(true);


### PR DESCRIPTION
アノテーションの有無でdomainの初期値が変わってしまうバグを修正しました。
合わせて、初期値をチェクするユニットテストを追加しました。